### PR TITLE
Support for Profiles Without Image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spotify-playlist-manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spotify-playlist-manager",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-playlist-manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "scripts": {},
   "private": true,

--- a/packages/ui/src/app/components/me/Me.tsx
+++ b/packages/ui/src/app/components/me/Me.tsx
@@ -123,6 +123,8 @@ export const Me = () => {
       });
   };
 
+  const profileUrl = userData?.images[0]?.url;
+
   return (
     <ToasterContainer>
       <HeadingLevel>
@@ -142,7 +144,7 @@ export const Me = () => {
         </FlexGrid>
         {!loadingStates.me && !errors.me && userData && (
           <>
-            <Avatar size="scale4800" src={userData.images[0].url} />
+            {profileUrl && <Avatar size="scale4800" src={profileUrl} />}
             <LabelSmall>Display Name</LabelSmall>
             <ParagraphSmall>{userData.display_name}</ParagraphSmall>
             <LabelSmall>ID</LabelSmall>
@@ -159,12 +161,14 @@ export const Me = () => {
             <ParagraphSmall>
               <StyledLink href={userData.href}>{userData.href}</StyledLink>
             </ParagraphSmall>
-            <LabelSmall>Profile Image</LabelSmall>
-            <ParagraphSmall>
-              <StyledLink href={userData.images[0].url}>
-                {userData.images[0].url}
-              </StyledLink>
-            </ParagraphSmall>
+            {profileUrl && (
+              <>
+                <LabelSmall>Profile Image</LabelSmall>
+                <ParagraphSmall>
+                  <StyledLink href={profileUrl}>{profileUrl}</StyledLink>
+                </ParagraphSmall>
+              </>
+            )}
             <LabelSmall>Country</LabelSmall>
             <ParagraphSmall>{userData.country}</ParagraphSmall>
             <HeadingLevel>


### PR DESCRIPTION
If users don't set a profile image, the URL for that image is `undefined`, so previously that would cause the page to crash.  Don't do that.