### PR TITLE
Better Login Error Handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spotify-playlist-manager",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spotify-playlist-manager",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-playlist-manager",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "scripts": {},
   "private": true,

--- a/packages/ui/src/app/components/home/Home.tsx
+++ b/packages/ui/src/app/components/home/Home.tsx
@@ -15,7 +15,6 @@ export const Home = () => {
     state: { accessToken, refreshToken },
   } = useSpotifyAuth();
 
-  const [redirectUri, setRedirectUri] = useState('');
   const [hasError, setHasError] = useState(false);
 
   /**
@@ -32,34 +31,29 @@ export const Home = () => {
     }
   }, [hasError]);
 
-  // get the server to generate the redirect URL, but then place it in the DOM
+  // reset the error state when dependent resources change
   useEffect(() => {
-    if ((accessToken && refreshToken) || redirectUri) {
+    if (accessToken && refreshToken) {
       return;
     }
 
     setHasError(false);
-    fetch('/api/auth/login')
-      .then(async (response) => {
-        const { authRedirect } = await response.json();
-        setRedirectUri(authRedirect);
-      })
-      .catch(() => showErrorToast());
-  }, [accessToken, refreshToken, redirectUri, showErrorToast]);
+  }, [accessToken, refreshToken]);
 
   const navigate = useNavigate();
 
   const onLoginInitiate = () => {
     if (accessToken && refreshToken) {
       navigate('me');
-    }
-
-    if (!redirectUri) {
-      showErrorToast();
       return;
     }
 
-    window.location.href = redirectUri;
+    fetch('/api/auth/login')
+      .then(async (response) => {
+        const { authRedirect } = await response.json();
+        window.location.href = authRedirect;
+      })
+      .catch(() => showErrorToast());
   };
 
   return (


### PR DESCRIPTION
Originally, the home page would spam the user with dozens of error toasts if it could not retrieve the redirect URI for logging in—that wasn't a very helpful error message.

This PR defers the logic to retrieving the redirect URI until the user wants to login.