### PR TITLE
IaC Fixes

### DIFF
--- a/.github/workflows/main-1-deploy-infrastructure.yml
+++ b/.github/workflows/main-1-deploy-infrastructure.yml
@@ -27,4 +27,5 @@ jobs:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: 1.4
           terraform_wrapper: false
-      - run: 'terraform apply -auto-approve'
+      - run: terraform init
+      - run: terraform apply -auto-approve

--- a/.github/workflows/main-1-deploy-infrastructure.yml
+++ b/.github/workflows/main-1-deploy-infrastructure.yml
@@ -8,6 +8,7 @@ on:
       - main
     paths:
       - 'infrastructure/'
+      - '.github/workflows/main-1-deploy-infrastructure.yml'
       - '.firebaserc'
       - 'firebase.json'
 

--- a/.github/workflows/main-2-deploy-application.yml
+++ b/.github/workflows/main-2-deploy-application.yml
@@ -8,11 +8,10 @@ on:
       - main
     paths-ignore:
       - '.github/'
-      - '!.github/workflows/application-deploy.yml'
+      - '!.github/workflows/main-2-deploy-application.yml'
       - '.vscode/'
       - 'docs/'
       - 'infrastructure/'
-      - 'kubernetes/'
       - 'tools/'
       - '.editorconfig'
       - '.eslintrc.json'

--- a/.github/workflows/main-2-deploy-application.yml
+++ b/.github/workflows/main-2-deploy-application.yml
@@ -66,6 +66,7 @@ jobs:
       - id: package
         run: echo "contents=$(cat package.json)" >> "$GITHUB_OUTPUTS"
       - run: npx -y 'nx@{{ fromJSON(steps.package.outputs.contents)['devDependencies']['@nrwl/cli'] }}' build:docker server
+      - run: docker tag docker tag spm-server:latest us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest
       - run: echo '${{ steps.gcp_auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
       - run: docker push us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest
       - run: gcloud run deploy server --image us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest --revision-suffix "$(date +'%Y%m%d-%H%M%S')" --region us-central1

--- a/.github/workflows/pull-request-terraform-plan.yml
+++ b/.github/workflows/pull-request-terraform-plan.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'infrastructure/'
+      - '.github/workflows/pull-request-terraform-plan.yml'
 
 jobs:
   infrastructure:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,4 +66,17 @@ _\*Note: `<owner>` is currently `imyourmanzi`_
 1. Create a service account for Firebase hosting deployments and add it to GitHub with: `npx firebase init hosting:github`
    1. The **firebase-hosting-merge.yml** can be deleted (that's handled by [**application-deploy.yml**](.github/workflows/application-deploy.yml))
 1. Grant "Compute Engine default service account" the "Secret Manager Accessor Role"
-1. An initial `terraform apply` must be run from `main`, since future deploys rely on the GitHub "production" environment that will be created in this initial deploy.
+1. An initial deployment must be run from `main`, since future deploys rely on the server container image and GitHub "production" environment that will be created in this initial deploy:
+   1. Build and push the container image
+      ```sh
+      npx "nx@$(jq -r '.devDependencies["@nrwl/cli"]' package.json)" build:docker server
+      docker tag spm-server:latest us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest
+      gcloud auth configure-docker us-central1-docker.pkg.dev
+      docker push us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest
+      ```
+   1. Create infrastructure
+      ```sh
+      cd infrastructure/
+      terraform init
+      terraform apply
+      ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,12 @@ _\*Note: `<owner>` is currently `imyourmanzi`_
    1. The **firebase-hosting-merge.yml** can be deleted (that's handled by [**application-deploy.yml**](.github/workflows/application-deploy.yml))
 1. Grant "Compute Engine default service account" the "Secret Manager Accessor Role"
 1. An initial deployment must be run from `main`, since future deploys rely on the server container image and GitHub "production" environment that will be created in this initial deploy:
+   1. Create initial infrastructure—this will fail to create the service but it will create the Artifact Registry repository which is what we need first (and yes there's a better way to do this that involves Terraform workspaces but we're not there yet)
+      ```
+      cd infrastructure/
+      terraform init
+      terraform apply
+      ```
    1. Build and push the container image
       ```sh
       npx "nx@$(jq -r '.devDependencies["@nrwl/cli"]' package.json)" build:docker server
@@ -74,9 +80,8 @@ _\*Note: `<owner>` is currently `imyourmanzi`_
       gcloud auth configure-docker us-central1-docker.pkg.dev
       docker push us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest
       ```
-   1. Create infrastructure
+   1. In GCP > Cloud Run > Services, delete the `server` service that failed initially—Terraform doesn't know it exists and will fail again if you don't delete it because it will try to create a new service with the same name
+   1. Finish creating infrastructure
       ```sh
-      cd infrastructure/
-      terraform init
       terraform apply
       ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spotify-playlist-manager",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spotify-playlist-manager",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-playlist-manager",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "MIT",
   "scripts": {},
   "private": true,

--- a/packages/server/project.json
+++ b/packages/server/project.json
@@ -34,8 +34,7 @@
         "cwd": ".",
         "commands": [
           "docker build --platform=linux/amd64 . -t spm-server:latest",
-          "docker tag spm-server:latest us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:latest",
-          "docker tag spm-server:latest \"us-central1-docker.pkg.dev/imyourmanzi-spotifyplaylistmgr/server-images/server:$(date +'%Y%m%dT%H%M%S')\""
+          "docker tag spm-server:latest \"spm-server:$(date +'%Y%m%dT%H%M%S')\""
         ],
         "parallel": false,
         "color": true
@@ -45,7 +44,11 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": ".",
-        "command": "docker build --platform=linux/arm64 . -t spm-server:latest-m1",
+        "commands": [
+          "docker build --platform=linux/arm64 . -t spm-server:latest-m1",
+          "docker tag spm-server:latest-m1 \"spm-server:$(date +'%Y%m%dT%H%M%S')-m1\""
+        ],
+        "parallel": false,
         "color": true
       }
     },


### PR DESCRIPTION
I kinda assumed I'd have some bugs in my GitHub deployment workflows and initial setup steps, so this PR fixes those things.

## Fixes

- infrastructure deployment needs to `init` before `apply`
- Docker image tags for Artifact Registry should be handled by the GitHub workflow, not the Nx runner
- need to push an image to Artifact Registry to get Cloud Run service to succeed
- update GitHub workflows that specify or ignore paths to use correct, up-to-date file names and paths